### PR TITLE
Fix results in random books

### DIFF
--- a/db/migrate/20200809000449_set_default_pages_and_max_stars.rb
+++ b/db/migrate/20200809000449_set_default_pages_and_max_stars.rb
@@ -1,0 +1,6 @@
+class SetDefaultPagesAndMaxStars < ActiveRecord::Migration[5.0]
+  def change
+      change_column :books, :pages, :int, :default => 0
+      Book.update_all(:pages => 0)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200801232355) do
+ActiveRecord::Schema.define(version: 20200809000449) do
 
   create_table "books", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string   "title"
@@ -26,7 +26,7 @@ ActiveRecord::Schema.define(version: 20200801232355) do
     t.string   "genre"
     t.integer  "rating"
     t.integer  "user_id"
-    t.integer  "pages"
+    t.integer  "pages",                     default: 0
     t.index ["user_id"], name: "index_books_on_user_id", using: :btree
   end
 


### PR DESCRIPTION
By default, all books will have 0 pages unless different value is defined. This will help the random to work properly as the condition is "less than 200 pages and not NULL". Other option could have been remove the `NULL` part of the condition.