### PR TITLE
Fix active storage issue

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,0 +1,7 @@
+test:
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage") %>
+
+local:
+  service: Disk
+  root: <%= Rails.root.join("storage") %>


### PR DESCRIPTION
Fix the following:
```
/usr/local/bundle/gems/activestorage-6.1.4.1/lib/active_storage/engine.rb:122:in `block (2 levels) in <class:Engine>': Couldn't find Active Storage configuration in /usr/src/app/conf
ig/storage.yml (RuntimeError)
```